### PR TITLE
Initial upgrades

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# http://editorconfig.org/
+# GitHub respects this file to display their diffs / code reviews if in repo root
+# Seen in https://github.com/isaacs/github/issues/170 as a way to solve the 8 spaces tabs
+root = true
+
+# NOTE: exception to Google Style, which is generally 80
+[*]
+line_width=100
+charset = utf-8
+
+[*.java]
+indent_style = space
+indent_size = 4
+
+# https://google.github.io/styleguide/jsguide.html#formatting-block-indentation
+[*.{js,json}]
+indent_style = space
+indent_size = 2
+
+# https://google.github.io/styleguide/htmlcssguide.xml#Indentation
+[*.{html,htm,hbs}]
+indent_style = space
+indent_size = 2
+
+
+# force-wrap markdown files to 100 column width
+[.md]
+max_line_length = 100

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+> Description here
+>
+
+### Fixes
+> refer to GitHub issues here
+
+### Features
+> refer to GitHub issues here
+
+### Change implications
+
+ - breaking change to API? **yes/no**
+ - changes dependendencies?  **yes/no**

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 *.iml
+java/target/

--- a/java/README
+++ b/java/README
@@ -1,4 +1,0 @@
-To build the library:
-$ ant
-appengine-pipeline.jar will be in dist/lib.
-

--- a/java/README.md
+++ b/java/README.md
@@ -1,9 +1,15 @@
-# App Engine Pipeline Framework for JAva
+# App Engine Pipeline Framework for Java
 
 
 ## Continuous Integration
 [![Codeship Status for Worklytics/appengine-pipelines](https://app.codeship.com/projects/341fae40-195c-0137-b96c-1a1a0859fc7b/status?branch=master)](https://app.codeship.com/projects/328456)
 
+
+## Change Log
+
+### v0.4
+  - policy for retries against Cloud Datastore / Cloud Tasks APIs has changed slightly, so behavior under failure conditions may vary from prior versions
+  
 
 ## Building
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,6 +1,10 @@
 # App Engine Pipeline Framework for JAva
 
 
+## Continuous Integration
+[![Codeship Status for Worklytics/appengine-pipelines](https://app.codeship.com/projects/341fae40-195c-0137-b96c-1a1a0859fc7b/status?branch=master)](https://app.codeship.com/projects/328456)
+
+
 ## Building
 
 ### Maven

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,27 @@
+# App Engine Pipeline Framework for JAva
+
+
+## Building
+
+### Maven
+Run tests:
+```bash
+mvn test
+``` 
+
+Package:
+```bash
+mvn package
+```
+
+Your JAR will be in `java/target/`
+
+
+### Ant - YMMV
+To build the library:
+```bash
+$ ant
+```
+
+`appengine-pipeline.jar` will be in dist/lib.
+

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,7 +9,7 @@
   <organization>
     <name>Google</name>
   </organization>
-  <version>0.3-SNAPSHOT</version>
+  <version>0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <licenses>
     <license>
@@ -26,8 +26,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20090211</version>
+      <version>20180813</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -107,11 +107,6 @@
       <version>2.5</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.appengine.tools</groupId>
-      <artifactId>appengine-gcs-client</artifactId>
-      <version>[0.8,1.0)</version>
-    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -107,6 +107,11 @@
       <version>2.5</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+      <version>2.0.0</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.google.appengine.tools</groupId>
       <artifactId>appengine-gcs-client</artifactId>
-      <version>[0.4,1.0)</version>
+      <version>[0.8,1.0)</version>
     </dependency>
     <!-- Test Dependencies -->
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -85,6 +85,10 @@
       <artifactId>json</artifactId>
       <version>20180813</version>
     </dependency>
+    <!-- will be deprecated in GAE Java 11 env. need to replace with:
+     1) Cloud Tasks : https://developers.google.com/api-client-library/java/apis/cloudtasks/v2
+     2) Cloud Data store : https://cloud.google.com/datastore/docs/reference/libraries#client-libraries-install-java
+     -->
     <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20180813</version>
+      <version>20190722</version>
     </dependency>
     <!-- will be deprecated in GAE Java 11 env. need to replace with:
      1) Cloud Tasks : https://developers.google.com/api-client-library/java/apis/cloudtasks/v2

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineTaskQueue.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineTaskQueue.java
@@ -68,7 +68,7 @@ public class AppEngineTaskQueue implements PipelineTaskQueue {
     Queue queue = getQueue(task.getQueueSettings().getOnQueue());
     try {
       queue.add(taskOptions);
-    } catch (TaskAlreadyExistsException ingore) {
+    } catch (TaskAlreadyExistsException ignore) {
       // ignore
     }
   }


### PR DESCRIPTION
  * java8
  * removes dependency in `appengine-gcs` entirely; lib was only re-using some retrying logic out of that, used Guava Retrying project instead (although it has its own problems, the gcs lib is obsolete and carries a lot other than retrying logic in it)