### PR TITLE
nicer serialization of JDK8 classes in pipeline UX

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -144,6 +144,11 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <dependency> <!-- does this force min Jackson version?? -->
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -149,6 +149,11 @@
       <artifactId>jackson-datatype-jdk8</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -16,11 +16,9 @@ package com.google.appengine.tools.pipeline.impl.util;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.util.Map;
 
@@ -30,7 +28,13 @@ import java.util.Map;
  */
 public class JsonUtils {
 
-  static ObjectMapper objectToJsonMapper = new ObjectMapper();
+  static ObjectMapper objectToJsonMapper;
+
+  //initialize ObjectMapper
+  static  {
+    objectToJsonMapper = new ObjectMapper();
+    objectToJsonMapper.registerModule(new Jdk8Module());
+  }
 
   public static String mapToJson(Map<?, ?> map) {
     try {

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.util.Map;
 
@@ -33,7 +34,9 @@ public class JsonUtils {
   //initialize ObjectMapper
   static  {
     objectToJsonMapper = new ObjectMapper();
-    objectToJsonMapper.registerModule(new Jdk8Module());
+    objectToJsonMapper.registerModule(new Jdk8Module());  //java.util.Optional, Streams
+    objectToJsonMapper.registerModule(new JavaTimeModule());
+    objectToJsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
   }
 
   public static String mapToJson(Map<?, ?> map) {

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/servlets/JsonGeneratorTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/servlets/JsonGeneratorTest.java
@@ -4,6 +4,8 @@ import com.google.appengine.tools.pipeline.*;
 import com.google.appengine.tools.pipeline.impl.PipelineManager;
 import com.google.appengine.tools.pipeline.impl.model.JobRecord;
 import com.google.appengine.tools.pipeline.impl.model.PipelineObjects;
+import com.google.appengine.tools.pipeline.impl.util.JsonUtils;
+import org.junit.Test;
 
 import java.util.Map;
 
@@ -69,6 +71,7 @@ public class JsonGeneratorTest extends PipelineTest {
 //    int length = EXAMPLE_JSON_RESPONSE.length();
 //    assertEquals(EXAMPLE_JSON_RESPONSE.substring(length - 100, length), json.substring(length - 100, length));
 //  }
+
 
   private String stripWhitespace(String s) {
     return s.replaceAll("\\s+","");

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
@@ -1,8 +1,11 @@
 package com.google.appengine.tools.pipeline.impl.util;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
@@ -10,15 +13,15 @@ import static org.junit.Assert.*;
 public class JsonUtilsTest {
 
 
+  @Getter
+  @JsonPropertyOrder({"instant", "full", "empty"})  //make test deterministic
   public static class Jdk8Bean {
 
-    public Optional<String> getFull() {
-      return Optional.of("string");
-    }
+    private Instant instant = Instant.parse("2020-01-01T12:00:00Z");
 
-    public Optional<String> getEmpty() {
-      return Optional.ofNullable(null);
-    }
+    private Optional<String> full = Optional.of("string");
+
+    private Optional<String> empty = Optional.ofNullable(null);
 
   }
 
@@ -27,8 +30,9 @@ public class JsonUtilsTest {
 
     String JSON_WITH_UNWRAPPED_OPTIONALS = "{\n" +
       "  \"bean\" : {\n" +
-      "    \"empty\" : null,\n" +
-      "    \"full\" : \"string\"\n" +
+      "    \"instant\" : \"2020-01-01T12:00:00Z\",\n" +
+      "    \"full\" : \"string\",\n" +
+      "    \"empty\" : null\n" +
       "  }\n" +
       "}";
 

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
@@ -1,0 +1,40 @@
+package com.google.appengine.tools.pipeline.impl.util;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class JsonUtilsTest {
+
+
+  public static class Jdk8Bean {
+
+    public Optional<String> getFull() {
+      return Optional.of("string");
+    }
+
+    public Optional<String> getEmpty() {
+      return Optional.ofNullable(null);
+    }
+
+  }
+
+  @Test
+  public void jdk8() {
+
+    String JSON_WITH_UNWRAPPED_OPTIONALS = "{\n" +
+      "  \"bean\" : {\n" +
+      "    \"empty\" : null,\n" +
+      "    \"full\" : \"string\"\n" +
+      "  }\n" +
+      "}";
+
+    String json = JsonUtils.mapToJson(ImmutableMap.of("bean", new Jdk8Bean()));
+
+    assertEquals(JSON_WITH_UNWRAPPED_OPTIONALS, json);
+  }
+
+}


### PR DESCRIPTION
### Features
 - deal with fact that, by default, Jackson skips `Optional<>`; this changes that behavior to map those to either `null` or their actual wrapped value

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes**
