### PR TITLE
don't serialize data with explicit JsonView set

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -29,6 +29,7 @@ import java.util.Map;
  */
 public class JsonUtils {
 
+  //q: expose this so its behavior can be configured??
   static ObjectMapper objectToJsonMapper;
 
   //initialize ObjectMapper
@@ -36,7 +37,10 @@ public class JsonUtils {
     objectToJsonMapper = new ObjectMapper();
     objectToJsonMapper.registerModule(new Jdk8Module());  //java.util.Optional, Streams
     objectToJsonMapper.registerModule(new JavaTimeModule());
+
     objectToJsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    //set explicit view for object mapper, so anything annotated with an explicit @JsonView won't be shown by default
+    objectToJsonMapper.setConfig(objectToJsonMapper.getSerializationConfig().withView(Object.class));
   }
 
   public static String mapToJson(Map<?, ?> map) {

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
@@ -1,6 +1,7 @@
 package com.google.appengine.tools.pipeline.impl.util;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import org.junit.Test;
@@ -37,6 +38,34 @@ public class JsonUtilsTest {
       "}";
 
     String json = JsonUtils.mapToJson(ImmutableMap.of("bean", new Jdk8Bean()));
+
+    assertEquals(JSON_WITH_UNWRAPPED_OPTIONALS, json);
+  }
+
+  @Getter
+  public static class SecretBean {
+
+    private String notASecret = "public";
+
+    @JsonView(Secret.class)
+    private String secret = "something secret";
+
+  }
+
+  public static class Secret {
+
+  }
+
+  @Test
+  public void secret() {
+
+    String JSON_WITH_UNWRAPPED_OPTIONALS = "{\n" +
+      "  \"bean\" : {\n" +
+      "    \"notASecret\" : \"public\"\n" +
+      "  }\n" +
+      "}";
+
+    String json = JsonUtils.mapToJson(ImmutableMap.of("bean", new SecretBean()));
 
     assertEquals(JSON_WITH_UNWRAPPED_OPTIONALS, json);
   }

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/util/JsonUtilsTest.java
@@ -59,7 +59,7 @@ public class JsonUtilsTest {
   @Test
   public void secret() {
 
-    String JSON_WITH_UNWRAPPED_OPTIONALS = "{\n" +
+    String JSON_WITH_SECRET = "{\n" +
       "  \"bean\" : {\n" +
       "    \"notASecret\" : \"public\"\n" +
       "  }\n" +
@@ -67,7 +67,7 @@ public class JsonUtilsTest {
 
     String json = JsonUtils.mapToJson(ImmutableMap.of("bean", new SecretBean()));
 
-    assertEquals(JSON_WITH_UNWRAPPED_OPTIONALS, json);
+    assertEquals(JSON_WITH_SECRET, json);
   }
 
 }


### PR DESCRIPTION

### Features
 - don't serialize properties with explicit `@JsonView` set

### Change implications

 - breaking change to API? **no**
 - changes dependendencies?  **no**
