### PR TITLE
S67 fixes

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11 # maven won't accept --release argument with java < 8; and 11 is next LTS
       - name: Build with Maven
         run: |
           cd java/

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,8 +16,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <appengine.target.version>[1.9.1,2.0)</appengine.target.version>
-    <jackson.version>[2.7,2.99)</jackson.version> <!-- 2.7+ is needed for JDK8 data type serialization -->
+    <appengine.target.version>[1.9.1, 2.0)</appengine.target.version>
+    <jackson.version>[2.7, 3.0)</jackson.version> <!-- 2.7+ is needed for JDK8 data type serialization -->
   </properties>
 
   <distributionManagement>
@@ -38,6 +38,7 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>
@@ -144,7 +145,7 @@
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-    <dependency> <!-- does this force min Jackson version?? -->
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
       <version>${jackson.version}</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <appengine.target.version>[1.9.1,2.0)</appengine.target.version>
-    <jackson.version>[2.6,2.99)</jackson.version>
+    <jackson.version>[2.7,2.99)</jackson.version> <!-- 2.7+ is needed for JDK8 data type serialization -->
   </properties>
 
   <distributionManagement>

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -63,7 +64,7 @@ public class JsonUtils {
   public static Map<String, ?> fromJson(String json) {
     try {
       return objectToJsonMapper.readValue(json, Map.class);
-    } catch (JsonProcessingException e) {
+    } catch (IOException e) {
       throw new RuntimeException("json=" + json, e);
     }
   }


### PR DESCRIPTION
### Fixes
 - when not built on machine w jdk8, weird bugs happen; even though source/target set to java8, need to also specify it for 'release'

### Change implications

 - breaking change to API? **no**
 - changes dependendencies?  **yes** jackson to >=2.7
