### PR TITLE
don't fail on what pipelines UX sees as 'empty' beans

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -40,6 +40,7 @@ public class JsonUtils {
     objectToJsonMapper.registerModule(new JavaTimeModule());
 
     objectToJsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    objectToJsonMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     //set explicit view for object mapper, so anything annotated with an explicit @JsonView won't be shown by default
     objectToJsonMapper.setConfig(objectToJsonMapper.getSerializationConfig().withView(Object.class));
   }


### PR DESCRIPTION
### Fixes
 - avoid failing on empty beans when serializing JSON

### Change implications

 - breaking change to API? **no**
 - changes dependendencies?  **no**
