### PR TITLE
Disable FAIL_ON_SELF_REFERENCES when deserializing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@
 ### Change implications
 
  - breaking change to API? **yes/no**
- - changes dependendencies?  **yes/no**
+ - changes dependencies?  **yes/no**

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -7,11 +7,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 11 # maven won't accept --release argument with java < 8; and 11 is next LTS
+          distribution: 'adopt'
+          java-version: '11' # maven won't accept --release argument with java < 8; and 11 is next LTS
+      - name: Maven compile
+          run: |
+            cd java/
+            mvn clear compile
       - name: Build with Maven
         run: |
           cd java/

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -13,7 +13,7 @@ jobs:
           distribution: 'adopt'
           java-version: '11' # maven won't accept --release argument with java < 8; and 11 is next LTS
       - name: Maven compile
-          run: |
+        run: |
             cd java/
             mvn clear compile
       - name: Build with Maven

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Maven compile
         run: |
             cd java/
-            mvn clear compile
+            mvn clean compile
       - name: Build with Maven
         run: |
           cd java/

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,7 +18,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <appengine.target.version>[1.9.1, 2.0)</appengine.target.version>
+    <appengine.target.version>1.9.80</appengine.target.version>
+    <!-- <appengine.target.version>[1.9.1, 2.0)</appengine.target.version> -->
     <jackson.version>[2.7, 3.0)</jackson.version> <!-- 2.7+ is needed for JDK8 data type serialization -->
   </properties>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
   <url>https://github.com/Worklytics/appengine-pipelines/</url>
   <!-- follow semver, with suggested guidance for versioning fork of OSS -->
   <!-- see https://gofore.com/en/best-practices-for-forking-a-git-repo/ -->
-  <version>0.3+worklytics.1</version>
+  <version>0.3+worklytics.2</version>
   <packaging>jar</packaging>
   <licenses>
     <license>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <version>0.3+worklytics.2</version>
   <packaging>jar</packaging>
   <licenses>
-    <license>https://github.com/Worklytics/appengine-pipelines/actions/runs/919764886/workflow
+    <license>
       <name>The Apache Software License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0</url>
     </license>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <version>0.3+worklytics.2</version>
   <packaging>jar</packaging>
   <licenses>
-    <license>
+    <license>https://github.com/Worklytics/appengine-pipelines/actions/runs/919764886/workflow
       <name>The Apache Software License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0</url>
     </license>

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/util/JsonUtils.java
@@ -41,6 +41,7 @@ public class JsonUtils {
 
     objectToJsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectToJsonMapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    objectToJsonMapper.disable(SerializationFeature.FAIL_ON_SELF_REFERENCES);
     //set explicit view for object mapper, so anything annotated with an explicit @JsonView won't be shown by default
     objectToJsonMapper.setConfig(objectToJsonMapper.getSerializationConfig().withView(Object.class));
   }


### PR DESCRIPTION
An attempt to fix the pipeline display issues with self references.
https://fasterxml.github.io/jackson-databind/javadoc/2.6/com/fasterxml/jackson/databind/SerializationFeature.html#FAIL_ON_SELF_REFERENCES
Is enabled by default.

### Change implications

 - breaking change to API? **no**
 - changes dependendencies?  **no**
