### PR TITLE
S175 : revert jakarta

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -130,12 +130,6 @@
       <version>[32.1,32.99]</version>
     </dependency>
     <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency> <!-- left bc GAE queues still seems to need it ?? -->
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
       <version>2.5</version>

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/AbortJobHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/AbortJobHandler.java
@@ -16,15 +16,13 @@ package com.google.appengine.tools.pipeline.impl.servlets;
 
 import com.google.appengine.tools.pipeline.NoSuchObjectException;
 import com.google.appengine.tools.pipeline.PipelineOrchestrator;
-import com.google.appengine.tools.pipeline.PipelineRunner;
-import com.google.appengine.tools.pipeline.impl.PipelineManager;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author ozarov@google.com (Arie Ozarov)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/DeleteJobHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/DeleteJobHandler.java
@@ -21,9 +21,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author ozarov@google.com (Arie Ozarov)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonClassFilterHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonClassFilterHandler.java
@@ -24,8 +24,8 @@ import lombok.RequiredArgsConstructor;
 import java.io.IOException;
 import java.util.Set;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author rudominer@google.com (Mitch Rudominer)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonListHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonListHandler.java
@@ -22,9 +22,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author tkaitchuck@google.com (Tom Kaitchuck)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonTreeHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/JsonTreeHandler.java
@@ -23,9 +23,9 @@ import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author rudominer@google.com (Mitch Rudominer)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/PipelineServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/PipelineServlet.java
@@ -15,7 +15,6 @@
 package com.google.appengine.tools.pipeline.impl.servlets;
 
 import com.google.appengine.tools.pipeline.DaggerDefaultContainer;
-import com.google.appengine.tools.pipeline.DefaultDIModule;
 import com.google.appengine.tools.pipeline.PipelineOrchestrator;
 import com.google.appengine.tools.pipeline.PipelineRunner;
 import com.google.appengine.tools.pipeline.impl.PipelineManager;
@@ -27,10 +26,10 @@ import lombok.SneakyThrows;
 import java.io.IOException;
 
 import javax.inject.Inject;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 
 /**

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/StaticContentHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/StaticContentHandler.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author rudominer@google.com (Mitch Rudominer)

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/TaskHandler.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/servlets/TaskHandler.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * A ServletHelper that handles all requests from the task queue.

--- a/java/src/test/java/com/google/appengine/tools/pipeline/JsonClassFilterHandlerTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/JsonClassFilterHandlerTest.java
@@ -32,8 +32,8 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Test for {@link JsonClassFilterHandler}.

--- a/java/src/test/java/com/google/appengine/tools/pipeline/JsonListHandlerTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/JsonListHandlerTest.java
@@ -34,8 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 
 /**


### PR DESCRIPTION
### Fixes
 - jakarta causes problems with cloud tasks via AppEngine SDK, which we still use; not worth fixing bc move to micronaut will eliminate servlets

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes**
