### PR TITLE
S187 more id fixes

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerParams.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 @Data
 class ShufflerParams implements Serializable, GcpCredentialOptions {
 
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 3L;
 
   private String shufflerQueue;
   private String gcsBucket;
@@ -39,6 +39,15 @@ class ShufflerParams implements Serializable, GcpCredentialOptions {
   private String[] inputFileNames;
   private String outputDir;
   private String serviceAccountKey;
+
+  /**
+   * if provided, this value will be used as the manifest file name instead of generated manifest file name from job id
+   * NOTE: will cause conflicts/overwrites if multiple jobs are writing to the same bucket/directory, with same manifestFileNameOverride value
+   *
+   * use case for this is testing, where we want to inspect manifest file contents
+   * @see {@link ShufflerServletTest}
+   */
+  private String manifestFileNameOverride;
 
   private int outputShards;
   private String callbackQueue;

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/EndToEndTest.java
@@ -661,7 +661,7 @@ public class EndToEndTest extends EndToEndTestCase {
       assertNull(info.getOutput());
       assertEquals(JobInfo.State.STOPPED_BY_ERROR, info.getJobState());
       assertTrue(info.getException().getMessage()
-          .matches("Stage .*//map-.* was not completed successfuly \\(status=ERROR, message=.*\\)"));
+          .matches("Stage .*:::map-.* was not completed successfuly \\(status=ERROR, message=.*\\)"));
     }
 
     // Disallow slice-retry


### PR DESCRIPTION
### Fixes
 - shuffler test fails, actually due to it using pipeline ID to generate shuffle manifest, which I think actually creates some risk of collision - so refactored that a bit
 - then error handler test failing, just due to REGEX not matching new delimiter
 
### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
