### PR TITLE
move lookup of tasks to NOT be within a txn

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/IncrementalTaskState.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/IncrementalTaskState.java
@@ -171,8 +171,18 @@ public class IncrementalTaskState<T extends IncrementalTask> {
       return taskState.build();
     }
 
-    static <T extends IncrementalTask> IncrementalTaskState<T> fromEntity(Transaction tx, Entity in) {
+    public static <T extends IncrementalTask> IncrementalTaskState<T> fromEntity(Transaction tx, Entity in) {
       return fromEntity(tx, in, false);
+    }
+
+    public static <T extends IncrementalTask> IncrementalTaskState<T> fromEntity(
+      @NonNull Datastore datastore,
+      Entity in,
+      boolean lenient) {
+      Transaction txn = datastore.newTransaction();
+      IncrementalTaskState<T> state = fromEntity(txn, in, lenient);
+      txn.commit();
+      return state;
     }
 
     public static <T extends IncrementalTask> IncrementalTaskState<T> fromEntity(

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
@@ -113,16 +113,9 @@ public class ShardedJobRunner implements ShardedJobHandler {
 
   public <T extends IncrementalTask> List<IncrementalTaskState<T>> lookupTasks(
     final ShardedJobRunId jobId, final int taskCount, final boolean lenient) {
-    Transaction tx = datastore.newTransaction();
-    try {
-      List<IncrementalTaskState<T>> taskStates = new ArrayList<>();
-      Iterators.addAll(taskStates, lookupTasks(tx, jobId, taskCount, lenient));
-      tx.commit();
-      return taskStates;
-    } finally {
-      //should be read-only, so no need to rollback
-      rollbackIfActive(tx);
-    }
+    List<IncrementalTaskState<T>> taskStates = new ArrayList<>();
+    Iterators.addAll(taskStates, lookupTasks(datastore, jobId, taskCount, lenient));
+    return taskStates;
   }
 
 
@@ -150,7 +143,7 @@ public class ShardedJobRunner implements ShardedJobHandler {
   }
 
   private <T extends IncrementalTask> Iterator<IncrementalTaskState<T>> lookupTasks(
-    @NonNull Transaction tx, final ShardedJobRunId jobId, final int taskCount, final boolean lenient) {
+    @NonNull Datastore datastore, final ShardedJobRunId jobId, final int taskCount, final boolean lenient) {
 
     // does it in batches of 20, so prob not as slow as it seems ...
     return new AbstractIterator<>() {
@@ -161,20 +154,20 @@ public class ShardedJobRunner implements ShardedJobHandler {
       protected IncrementalTaskState<T> computeNext() {
         if (lastBatch.hasNext()) {
           Entity entity = lastBatch.next();
-          return IncrementalTaskState.Serializer.fromEntity(tx, entity, lenient);
+          return IncrementalTaskState.Serializer.fromEntity(datastore, entity, lenient);
         } else if (lastCount >= taskCount) {
           return endOfData();
         }
         int toRead = Math.min(TASK_LOOKUP_BATCH_SIZE, taskCount - lastCount);
         List<Key> keys = new ArrayList<>(toRead);
         for (int i = 0; i < toRead; i++, lastCount++) {
-          Key key = IncrementalTaskState.Serializer.makeKey(tx.getDatastore(), IncrementalTaskId.of(jobId, lastCount));
+          Key key = IncrementalTaskState.Serializer.makeKey(datastore, IncrementalTaskId.of(jobId, lastCount));
           keys.add(key);
         }
         TreeMap<Integer, Entity> ordered = new TreeMap<>();
-        for (Iterator<Entity> it = tx.get(keys.toArray(new Key[0])); it.hasNext(); ) {
+        for (Iterator<Entity> it = datastore.get(keys.toArray(new Key[0])); it.hasNext(); ) {
           Entity entry = it.next();
-          IncrementalTaskState state = IncrementalTaskState.Serializer.fromEntity(tx, entry);
+          IncrementalTaskState state = IncrementalTaskState.Serializer.fromEntity(datastore, entry, false);
           ordered.put(state.getShardNumber(), entry);
         }
         lastBatch = ordered.values().iterator();
@@ -184,9 +177,9 @@ public class ShardedJobRunner implements ShardedJobHandler {
   }
 
 
-  private <T extends IncrementalTask> void callCompleted(Transaction tx, ShardedJobStateImpl<T> jobState) {
+  private <T extends IncrementalTask> void callCompleted(Datastore datastore, ShardedJobStateImpl<T> jobState) {
     Iterator<IncrementalTaskState<T>> taskStates =
-      lookupTasks(tx, jobState.getShardedJobId(), jobState.getTotalTaskCount(), false);
+      lookupTasks(datastore, jobState.getShardedJobId(), jobState.getTotalTaskCount(), false);
     Iterator<T> tasks = Iterators.transform(taskStates, IncrementalTaskState::getTask);
     jobState.getController().setPipelineService(pipelineServiceProvider.get());
     jobState.getController().completed(tasks);
@@ -265,13 +258,7 @@ public class ShardedJobRunner implements ShardedJobHandler {
         // TODO(user): consider trying failed if completed failed after N attempts
 
         //q: should this be same txn as above??
-        Transaction tx = datastore.newTransaction();
-        try {
-          callCompleted(tx, jobState);
-          tx.commit();
-        } finally {
-          rollbackIfActive(tx);
-        }
+        callCompleted(datastore, jobState);
       } else {
         log.info("Calling failed for " + jobId + ", status=" + jobState.getStatus());
         jobState.getController().failed(jobState.getStatus());


### PR DESCRIPTION
### Fixes
 - concurrency in prod, with 40+ shards

so in practice, this seems to be a problem; and historically wasn't in a txn, so reverting to that behavior. that said, imho, seems like it kinda *should* be a txn (calling "completed()" on the job with a consistent view of state of all shards). Perhaps idea is that once individual shards completed, will not be updated further; and being at the point of calling `completed()` on the ShardedJob means we've already seen each shard in "completed" state?

https://github.com/GoogleCloudPlatform/appengine-mapreduce/blob/2f939bec84517a90126ac96772cdd4b5ade41f53/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java#L150-L189

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
