### PR TITLE
s192 - Minimum wait of 1s on retries

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapSettings.java
@@ -2,10 +2,8 @@
 
 package com.google.appengine.tools.mapreduce;
 
-import static com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobSettings.DEFAULT_SLICE_TIMEOUT_MILLIS;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.github.rholder.retry.*;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import com.google.appengine.api.modules.ModulesException;
 import com.google.appengine.api.modules.ModulesService;
 import com.google.appengine.api.modules.ModulesServiceFactory;
@@ -27,7 +25,9 @@ import lombok.ToString;
 import java.io.Serializable;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+
+import static com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobSettings.DEFAULT_SLICE_TIMEOUT_MILLIS;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Settings that affect how a Map job is executed.  May affect performance and
@@ -44,14 +44,14 @@ public class MapSettings implements Serializable {
 
   private static RetryerBuilder getQueueRetryerBuilder() {
     return RetryerBuilder.newBuilder()
-      .withWaitStrategy(WaitStrategies.exponentialWait(20_000, TimeUnit.MILLISECONDS))
+      .withWaitStrategy(WaitStrategiesUtils.defaultWaitStrategy())
       .withStopStrategy(StopStrategies.stopAfterAttempt(8))
       .retryIfExceptionOfType(TransientFailureException.class);
   }
 
   private static RetryerBuilder getModulesRetryerBuilder() {
     return RetryerBuilder.newBuilder()
-      .withWaitStrategy(WaitStrategies.exponentialWait(20_000, TimeUnit.MILLISECONDS))
+      .withWaitStrategy(WaitStrategiesUtils.defaultWaitStrategy())
       .withStopStrategy(StopStrategies.stopAfterAttempt(8))
       .retryIfExceptionOfType(ModulesException.class);
   }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/WaitStrategiesUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/WaitStrategiesUtils.java
@@ -1,0 +1,17 @@
+package com.google.appengine.tools.mapreduce;
+
+import com.github.rholder.retry.WaitStrategies;
+import com.github.rholder.retry.WaitStrategy;
+
+import java.util.concurrent.TimeUnit;
+
+public class WaitStrategiesUtils {
+
+  public static WaitStrategy defaultWaitStrategy() {
+    return WaitStrategies.join(
+      WaitStrategies.fixedWait(1_000, TimeUnit.MILLISECONDS),
+      WaitStrategies.exponentialWait(30_000, TimeUnit.MILLISECONDS)
+    );
+  }
+
+}

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/servlets/ShufflerServlet.java
@@ -14,11 +14,8 @@
 
 package com.google.appengine.tools.mapreduce.servlets;
 
-import static java.util.concurrent.Executors.callable;
-
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
-import com.github.rholder.retry.WaitStrategies;
 import com.google.appengine.api.modules.ModulesServiceFactory;
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.QueueFactory;
@@ -26,7 +23,6 @@ import com.google.appengine.api.taskqueue.TaskAlreadyExistsException;
 import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.tools.mapreduce.*;
 import com.google.appengine.tools.mapreduce.impl.MapReduceConstants;
-import com.google.appengine.tools.mapreduce.impl.shardedjob.ShardedJobRunId;
 import com.google.appengine.tools.mapreduce.impl.util.RequestUtils;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLevelDbInput;
 import com.google.appengine.tools.mapreduce.inputs.GoogleCloudStorageLineInput;
@@ -49,9 +45,14 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
+
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
-
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
@@ -60,17 +61,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.apache.commons.codec.digest.DigestUtils;
+import static java.util.concurrent.Executors.callable;
 
 /**
  * This servlet provides a way for Python MapReduce Jobs to use the Java MapReduce as a shuffle. It
@@ -100,7 +94,7 @@ public class ShufflerServlet extends HttpServlet {
           || e instanceof RequestTooLargeException
           || e instanceof ArgumentException)
       )
-      .withWaitStrategy(WaitStrategies.exponentialWait(30_000, TimeUnit.MILLISECONDS))
+      .withWaitStrategy(WaitStrategiesUtils.defaultWaitStrategy())
       .withStopStrategy(StopStrategies.stopAfterAttempt(10));
   }
 


### PR DESCRIPTION
### Features
- [optimistic concurrency thing ](https://app.asana.com/0/1206768215841274/1209276375478346)
- Enforce a minimum wait on retries. 
- Standardize all waits to 1s + 30s exponential backoff

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
