### PR TITLE
s192 - retry if message says so

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
@@ -24,10 +24,12 @@ public class RetryUtils {
     return new RetryListener() {
       @Override
       public <V> void onRetry(Attempt<V> attempt) {
-        if (attempt.hasException()) {
-          log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()), attempt.getExceptionCause());
-        } else {
-          log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d. No exception?".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()));
+        if (attempt.getAttemptNumber() > 1 || attempt.hasException()) {
+          if (attempt.hasException()) {
+            log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()), attempt.getExceptionCause());
+          } else {
+            log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d. No exception?".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()));
+          }
         }
       }
     };

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
@@ -85,7 +85,7 @@ public class ShardedJobRunner implements ShardedJobHandler {
       .withWaitStrategy(RetryUtils.defaultWaitStrategy())
       .retryIfException(e -> {
         if (e instanceof DatastoreException) {
-          return ((DatastoreException) e).isRetryable();
+          return ((DatastoreException) e).isRetryable() || e.getMessage().contains("Please retry the transaction");
         }
         return false;
       })


### PR DESCRIPTION
### Fixes
my best guess: 
[console link](https://console.cloud.google.com/logs/query;cursorTimestamp=2025-01-31T01:47:37.917644Z;duration=PT1H;query=resource.type%3D%22gae_app%22%0Aresource.labels.module_id%3D%22jobs%22%0Aresource.labels.version_id%3D%22v846a%22%0AShardedJobRunner%0ADatastoreException%0Atimestamp%3D%222025-01-31T01:47:37.917644Z%22%0AinsertId%3D%22679c2bb9000e008c9fd2f57e%22?project=eval-engin)

2 ideas based on these logs:

1) the exception is wrapped in `RuntimeException`, so not handled
```
Caused by: java.lang.RuntimeException: com.google.cloud.datastore.DatastoreException: Optimstic transaction was aborted due to a conflict with another concurrent operation. 
This can occur when there are overlapping reads or writes by other transactions, 
causing contention with the current transaction. Please retry the transaction.
```
2) this `DatastoreException` is not retryable despite what the message says
```Caused by:  com.google.cloud.datastore.DatastoreException: Optimstic transaction was aborted due to a conflict with another concurrent operation. 
This can occur when there are overlapping reads or writes by other transactions, 
causing contention with the current transaction. Please retry the transaction., code=ABORTED
```


### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
