### PR TITLE
s192 - Better handle wrapped DatastoreExceptions

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
@@ -83,22 +83,7 @@ public class ShardedJobRunner implements ShardedJobHandler {
   public static RetryerBuilder getRetryerBuilder() {
     return RetryerBuilder.newBuilder()
       .withWaitStrategy(RetryUtils.defaultWaitStrategy())
-      .retryIfException( e -> {
-        if (e instanceof RuntimeException) {
-          // contains a DatastoreException in the cause
-          Throwable cause = e.getCause();
-          if (cause instanceof DatastoreException) {
-            return ((DatastoreException) cause).isRetryable() || cause.getMessage().contains("Please retry the transaction");
-          }
-        }
-        return false;
-      })
-      .retryIfException(e -> {
-        if (e instanceof DatastoreException) {
-          return ((DatastoreException) e).isRetryable() || e.getMessage().contains("Please retry the transaction");
-        }
-        return false;
-      })
+      .retryIfException(RetryUtils.handleDatastoreExceptionRetry())
       .retryIfExceptionOfType(ApiProxyException.class)
       .retryIfExceptionOfType(ConcurrentModificationException.class) // don't think this is thrown by new datastore lib
       .retryIfExceptionOfType(TransientFailureException.class)

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/RetryUtilsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/RetryUtilsTest.java
@@ -1,0 +1,51 @@
+package com.google.appengine.tools.mapreduce;
+
+import com.google.cloud.BaseServiceException;
+import com.google.cloud.datastore.DatastoreException;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.IntSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RetryUtilsTest {
+
+  @Test
+  void handleDatastoreExceptionRetry() {
+
+    // copied from DatastoreException.RETRYABLE_ERROR_CODES (private)
+    ImmutableSet<BaseServiceException.Error> retryableErrors = ImmutableSet.of(
+      new BaseServiceException.Error(10, "ABORTED", false),
+      new BaseServiceException.Error(4, "DEADLINE_EXCEEDED", false),
+      new BaseServiceException.Error(14, "UNAVAILABLE", true));
+    ImmutableSet<BaseServiceException.Error> nonRetryableErrors = ImmutableSet.of(
+      new BaseServiceException.Error(52222, "WHATEVER", false),
+      new BaseServiceException.Error(989898, "WHO_KNOWS", false));
+
+    for (BaseServiceException.Error error : retryableErrors) {
+      DatastoreException de = new DatastoreException(error.getCode(), "something broke", error.getReason(), true, null);
+      assertTrue(RetryUtils.handleDatastoreExceptionRetry().test(de));
+    }
+    for (BaseServiceException.Error error : nonRetryableErrors) {
+      DatastoreException de = new DatastoreException(error.getCode(), "something broke", error.getReason(), false, null);
+      assertFalse(RetryUtils.handleDatastoreExceptionRetry().test(de));
+    }
+
+    // Test with message containing "retry the transaction"
+    for (BaseServiceException.Error error : nonRetryableErrors) {
+      DatastoreException de = new DatastoreException(error.getCode(), "RETRY THE TRANSACTION", error.getReason(), false, null);
+      assertTrue(RetryUtils.handleDatastoreExceptionRetry().test(de));
+    }
+
+    // embedded DatastoreException
+    retryableErrors.forEach(error -> {
+      DatastoreException root = new DatastoreException(error.getCode(), "something broken", error.getReason(), true, null);
+      assertTrue(RetryUtils.handleDatastoreExceptionRetry().test(root));
+      Exception chain1 = new Exception("Test Exception 1", root);
+      Exception chain2 = new Exception("Test Exception 2", chain1);
+      assertTrue(RetryUtils.handleDatastoreExceptionRetry().test(chain2));
+    });
+
+  }
+}


### PR DESCRIPTION
### Fixes
- Follow up of #31 , now looking in any kind of Throwable as saw exception wrapped in ServletException.
[DatastoreException wrapped in ServletException](https://app.asana.com/0/1209236967267674/1209293298464314)

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
