### PR TITLE
s192 - Perform retries on runTask/updateTask

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/pipeline/DeleteShardsInfos.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/pipeline/DeleteShardsInfos.java
@@ -51,7 +51,7 @@ public class DeleteShardsInfos extends Job0<Void> {
       addParentKeyToList(tx, toDelete, ShardRetryState.Serializer.makeKey(datastore, taskId));
     }
     RetryExecutor.call(
-      ShardedJobRunner.getRetryerBuilder().withStopStrategy(StopStrategies.stopAfterAttempt(RetryUtils.SYMBOLIC_FOREVER)),
+      ShardedJobRunner.FOREVER_RETRYER,
       callable(() -> tx.delete(toDelete.toArray(new Key[toDelete.size()]))));
 
     tx.commit();

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/pipeline/FinalizeShardsInfos.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/pipeline/FinalizeShardsInfos.java
@@ -33,7 +33,7 @@ public class FinalizeShardsInfos extends Job0<Void> {
     Datastore datastore = datastoreOptions.getService();
 
     RetryExecutor.call(
-      ShardedJobRunner.getRetryerBuilder().withStopStrategy(StopStrategies.stopAfterAttempt(RetryUtils.SYMBOLIC_FOREVER)),
+      ShardedJobRunner.FOREVER_RETRYER,
       callable(() -> {
         Transaction tx = datastore.newTransaction();
 


### PR DESCRIPTION
### Fixes
`javax.servlet.ServletException: com.google.cloud.datastore.DatastoreException: Optimstic transaction was aborted`
Try to better control places were commits are done and apply retries if needed.

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
