### PR TITLE
S192 handle out of sync task states

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -6,6 +6,9 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ "com.google.appengine.tools.cloudtasktest", "com.google.appengine.tools.mapreduce", "com.google.appengine.tools.pipeline" ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -16,9 +19,9 @@ jobs:
         run: |
             cd java/
             mvn clean compile
-      - name: Build with Maven
+      - name: Run Tests for Package ${{ matrix.package }}
         env:
           APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY: ${{ secrets.APPENGINE_MAPREDUCE_CI_SERVICE_ACCOUNT_KEY }}
         run: |
           cd java/
-          mvn test
+          mvn test -Dtest=${{ matrix.package }}.**

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
@@ -9,6 +9,7 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -21,7 +22,8 @@ public class RetryUtils {
 
   public static WaitStrategy defaultWaitStrategy() {
     return WaitStrategies.join(
-      WaitStrategies.exponentialWait(1_000,30_000, TimeUnit.MILLISECONDS)
+      WaitStrategies.randomWait(200,TimeUnit.MILLISECONDS),
+      WaitStrategies.exponentialWait(1_000,10_000, TimeUnit.MILLISECONDS)
     );
   }
 
@@ -31,9 +33,9 @@ public class RetryUtils {
       public <V> void onRetry(Attempt<V> attempt) {
         if (attempt.getAttemptNumber() > 1 || attempt.hasException()) {
           if (attempt.hasException()) {
-            log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()), attempt.getExceptionCause());
+            log.log(Level.WARNING, "%s, Attempt #%d. Retrying...".formatted(className, attempt.getAttemptNumber()), attempt.getExceptionCause());
           } else {
-            log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d. No exception?".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()));
+            log.log(Level.WARNING, "%s, Attempt #%d OK, wait: %s".formatted(className, attempt.getAttemptNumber(), Duration.ofMillis(attempt.getDelaySinceFirstAttempt())));
           }
         }
       }

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/RetryUtils.java
@@ -22,8 +22,9 @@ public class RetryUtils {
 
   public static WaitStrategy defaultWaitStrategy() {
     return WaitStrategies.join(
-      WaitStrategies.randomWait(200,TimeUnit.MILLISECONDS),
-      WaitStrategies.exponentialWait(1_000,10_000, TimeUnit.MILLISECONDS)
+      WaitStrategies.randomWait(200, TimeUnit.MILLISECONDS),
+      // before we had 30s max, seems too high
+      WaitStrategies.exponentialWait(1_000, 10_000, TimeUnit.MILLISECONDS)
     );
   }
 

--- a/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/impl/shardedjob/ShardedJobRunner.java
@@ -282,8 +282,10 @@ public class ShardedJobRunner implements ShardedJobHandler {
       log.info(taskId + ": Task sequence number " + sequenceNumber + " already completed: "
         + taskState);
     } else {
-      //q : throw here??
       log.severe(taskId + " sequenceNumber=" + sequenceNumber + " : Task state is from the past: " + taskState);
+      // presumably we are reading an old state, maybe being updated concurrently?
+      // we should not proceed with this state, throw an ConcurrentModificationException to force retry
+      throw new ConcurrentModificationException("Task state is from the past: " + taskState);
     }
     return null;
   }

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineBackEnd.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineBackEnd.java
@@ -41,6 +41,7 @@ import lombok.SneakyThrows;
 import lombok.extern.java.Log;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -97,9 +98,9 @@ public class AppEngineBackEnd implements PipelineBackEnd, SerializationStrategy 
                   if (attempt.getAttemptNumber() > 1 || attempt.hasException()) {
                     String className = AppEngineBackEnd.class.getName();
                     if (attempt.hasException()) {
-                      log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()), attempt.getExceptionCause());
+                      log.log(Level.WARNING, "%s, Attempt #%d. Retrying...".formatted(className, attempt.getAttemptNumber()), attempt.getExceptionCause());
                     } else {
-                      log.log(Level.WARNING, "%s, Retry attempt: %d, wait: %d. No exception?".formatted(className, attempt.getAttemptNumber(), attempt.getDelaySinceFirstAttempt()));
+                      log.log(Level.WARNING, "%s, Attempt #%d OK, wait: %s".formatted(className, attempt.getAttemptNumber(), Duration.ofMillis(attempt.getDelaySinceFirstAttempt())));
                     }
                   }
                 }


### PR DESCRIPTION
### Fixes
- [task sequence in the past](https://app.asana.com/0/1209236967267674/1209295786177439)
- Not very clear why this could happen. Trying to follow up code but can't figure out why that desync happens.
- Best idea: throw Exception and retry in case the jobState read is "old" due to race condition

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
