### PR TITLE
upgrade mockito, drop easymock

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -263,11 +263,6 @@
        <version>4.11.0</version>
        <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <version>5.2.0</version> <!-- need 5.2.0 to solve all JDK 17 issues? see https://github.com/easymock/easymock/releases -->
-    </dependency>
 
   </dependencies>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -260,7 +260,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
        <artifactId>mockito-core</artifactId>
-       <version>4.11.0</version>
+       <version>5.15.2</version>
        <scope>test</scope>
     </dependency>
 

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/MapSettingsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/MapSettingsTest.java
@@ -11,6 +11,7 @@ import static com.google.appengine.tools.mapreduce.MapSettings.DEFAULT_SLICE_RET
 import static com.google.appengine.tools.mapreduce.MapSettings.WORKER_PATH;
 import static com.google.appengine.tools.pipeline.impl.servlets.PipelineServlet.makeViewerUrl;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import com.google.appengine.tools.development.testing.LocalModulesServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
@@ -26,8 +27,6 @@ import com.google.apphosting.api.ApiProxy;
 import com.google.apphosting.api.ApiProxy.Environment;
 
 import com.google.cloud.datastore.Datastore;
-import com.google.cloud.datastore.Key;
-import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -189,12 +188,13 @@ public class MapSettingsTest {
     assertEquals("v1", sjSettings.getVersion());
 
     settings = new MapSettings.Builder(settings).setModule("default").build();
-    Environment env = ApiProxy.getCurrentEnvironment();
-    Environment mockEnv = EasyMock.createNiceMock(Environment.class);
-    EasyMock.expect(mockEnv.getModuleId()).andReturn("default").atLeastOnce();
-    EasyMock.expect(mockEnv.getVersionId()).andReturn("2").atLeastOnce();
-    EasyMock.expect(mockEnv.getAttributes()).andReturn(env.getAttributes()).anyTimes();
-    EasyMock.replay(mockEnv);
+    Environment trueEnv = ApiProxy.getCurrentEnvironment();
+    HashMap<String, Object> attributes = new HashMap<>(trueEnv.getAttributes());
+    Environment mockEnv = mock(Environment.class);
+    when(mockEnv.getModuleId()).thenReturn("default");
+    when(mockEnv.getVersionId()).thenReturn("2");
+    when(mockEnv.getAttributes()).thenReturn(attributes);
+
     ApiProxy.setEnvironmentForCurrentThread(mockEnv);
     // Test when current module is the same as requested module
     try {
@@ -202,9 +202,11 @@ public class MapSettingsTest {
       assertEquals("default", sjSettings.getModule());
       assertEquals("2", sjSettings.getVersion());
     } finally {
-      ApiProxy.setEnvironmentForCurrentThread(env);
+      ApiProxy.setEnvironmentForCurrentThread(trueEnv);
     }
-    EasyMock.verify(mockEnv);
+
+    verify(mockEnv, atLeastOnce()).getModuleId();
+    verify(mockEnv, atLeastOnce()).getVersionId();
   }
 
   private String getPath(MapSettings settings, String jobId, String logicPath) {

--- a/java/src/test/java/com/google/appengine/tools/pipeline/TestUtils.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/TestUtils.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -84,21 +83,12 @@ public class TestUtils {
     return s.replaceAll("\\s+","");
   }
 
-  @Deprecated
-  public static void addDatastoreHeadersToRequestEasymock(HttpServletRequest request, DatastoreOptions datastoreOptions) {
-    expect(request.getParameter(RequestUtils.Params.DATASTORE_HOST))
-      .andReturn(datastoreOptions.getHost()).anyTimes();
-
-    expect(request.getParameter(RequestUtils.Params.DATASTORE_NAMESPACE))
-      .andReturn(datastoreOptions.getNamespace()).anyTimes();
-
-    expect(request.getParameter(RequestUtils.Params.DATASTORE_PROJECT_ID))
-      .andReturn(datastoreOptions.getProjectId()).anyTimes();
-
-    expect(request.getParameter(RequestUtils.Params.DATASTORE_DATABASE_ID))
-      .andReturn(datastoreOptions.getDatabaseId()).anyTimes();
-  }
-
+  /**
+   * add datastore headers to request mocked with Mockito
+   *
+   * @param request must be a Mockito mock
+   * @param datastoreOptions to add as headers
+   */
   public static void addDatastoreHeadersToRequest(HttpServletRequest request, DatastoreOptions datastoreOptions) {
     when(request.getParameter(eq(RequestUtils.Params.DATASTORE_HOST)))
       .thenReturn(datastoreOptions.getHost());


### PR DESCRIPTION
### Features
  - drop easymock
  - bump mockito from 4.x to 5.x

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes** (Mockito version has been bumped, easymock dropped)
