### PR TITLE
Handle null case on MRSettings

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
+++ b/java/src/main/java/com/google/appengine/tools/mapreduce/MapReduceSettings.java
@@ -216,7 +216,10 @@ public class MapReduceSettings implements GcpCredentialOptions, ShardedJobAbstra
 
     @Override
     public Builder maxSortMemory(Long maxSortMemory) {
-      Preconditions.checkArgument(maxSortMemory > -1L, "maxSortMemory cannot be negative");
+      if (maxSortMemory != null) {
+        Preconditions.checkArgument(maxSortMemory > -1L, "maxSortMemory cannot be negative");
+      }
+
       super.maxSortMemory(maxSortMemory);
       return this;
     }

--- a/java/src/test/java/com/google/appengine/tools/mapreduce/MapReduceSettingsTest.java
+++ b/java/src/test/java/com/google/appengine/tools/mapreduce/MapReduceSettingsTest.java
@@ -49,7 +49,7 @@ public class MapReduceSettingsTest {
     assertNull(mrSettings.getMaxSortMemory());
     assertEquals(DEFAULT_MERGE_FANIN, mrSettings.getMergeFanin());
     assertEquals(DEFAULT_MILLIS_PER_SLICE, mrSettings.getMillisPerSlice());
-    assertEquals(null, mrSettings.getModule());
+    assertNull(mrSettings.getModule());
     assertEquals(DEFAULT_SORT_BATCH_PER_EMIT_BYTES, mrSettings.getSortBatchPerEmitBytes());
     assertEquals(DEFAULT_SORT_READ_TIME_MILLIS, mrSettings.getSortReadTimeMillis());
     assertNull(mrSettings.getWorkerQueueName());
@@ -133,5 +133,12 @@ public class MapReduceSettingsTest {
       .module("m1");
     mrSettings = builder.build();
     assertEquals("m1", mrSettings.getModule());
+
+    builder = MapReduceSettings.builder()
+      .bucketName("app_default_bucket")
+      .maxSortMemory(null)
+      .module("m2");
+
+    assertNull(builder.build().getMaxSortMemory());
   }
 }


### PR DESCRIPTION
checkArgument will convert use `toLongValue` to perform the comparison, raising an NPE if the value provided is null.

### Fixes
[NPE on map settings](https://app.asana.com/0/1209760930085999/1209770841283068)

### Features
> refer to GitHub issues here

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
