### PR TITLE
s196 - Use fastutil core - instead of full jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -145,10 +145,11 @@
       <artifactId>json</artifactId>
       <version>20231013</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/it.unimi.dsi/fastutil-core -->
     <dependency>
       <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-      <version>[6.5,6.6)</version>
+      <artifactId>fastutil-core</artifactId>
+      <version>[8.5.1, 8.6.0)</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
### Fixes
- uses core version of library (-10Mb)

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes**
