### PR TITLE
S196 : fw improvements

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/model/Barrier.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/model/Barrier.java
@@ -16,6 +16,7 @@ package com.google.appengine.tools.pipeline.impl.model;
 
 import com.google.cloud.datastore.*;
 import com.google.appengine.tools.pipeline.impl.util.StringUtils;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -52,8 +53,8 @@ public class Barrier extends PipelineModelObject implements ExpiringDatastoreEnt
    * The type of Barrier
    */
   public enum Type {
-    RUN,
-    FINALIZE
+    RUN, // these are root-level entities in datastore
+    FINALIZE  //NOTE: these have parents (belong to entity group of job they finalize)
   }
 
   private static final String TYPE_PROPERTY = "barrierType";
@@ -63,13 +64,26 @@ public class Barrier extends PipelineModelObject implements ExpiringDatastoreEnt
   private static final String WAITING_ON_GROUP_SIZES_PROPERTY = "waitingOnGroupSizes";
 
   // persistent
+  @Getter
   private final Type type;
+  @Getter
   private final Key jobKey;
+  @Getter
   private boolean released;
+
+  /**
+   * may be null if this Barrier has not been inflated
+   */
+  @Getter
   private final List<Key> waitingOnKeys;
   private final List<Long> waitingOnGroupSizes;
 
+  /**
+   * -- GETTER --
+   *  May return null if this Barrier has not been inflated
+   */
   // transient
+  @Getter
   private List<SlotDescriptor> waitingOnInflated;
 
   /**
@@ -157,31 +171,8 @@ public class Barrier extends PipelineModelObject implements ExpiringDatastoreEnt
     }
   }
 
-  public Key getJobKey() {
-    return jobKey;
-  }
-
-  public Type getType() {
-    return type;
-  }
-
-  public boolean isReleased() {
-    return released;
-  }
-
   public void setReleased() {
     released = true;
-  }
-
-  public List<Key> getWaitingOnKeys() {
-    return waitingOnKeys;
-  }
-
-  /**
-   * May return null if this Barrier has not been inflated
-   */
-  public List<SlotDescriptor> getWaitingOnInflated() {
-    return waitingOnInflated;
   }
 
   public Object[] buildArgumentArray() {

--- a/java/src/test/java/com/google/appengine/tools/pipeline/impl/backend/PipelineTaskQueueTaskSpecTest.java
+++ b/java/src/test/java/com/google/appengine/tools/pipeline/impl/backend/PipelineTaskQueueTaskSpecTest.java
@@ -1,0 +1,42 @@
+package com.google.appengine.tools.pipeline.impl.backend;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PipelineTaskQueueTaskSpecTest {
+
+
+  @Test
+  public void testEquals() {
+    PipelineTaskQueue.TaskSpec taskSpec = PipelineTaskQueue.TaskSpec.builder()
+        .name("test")
+        .method(PipelineTaskQueue.TaskSpec.Method.GET)
+      .callbackPath("/test")
+        .service("testService")
+
+      .param("param1", "value1")
+        .build();
+
+    PipelineTaskQueue.TaskSpec taskSpec2 = PipelineTaskQueue.TaskSpec.builder()
+        .name("test")
+        .method(PipelineTaskQueue.TaskSpec.Method.GET)
+        .service("testService")
+        .callbackPath("/test")
+      .param("param1", "value1")
+        .build();
+
+    assertEquals(taskSpec, taskSpec2);
+
+    PipelineTaskQueue.TaskSpec taskSpec3 = PipelineTaskQueue.TaskSpec.builder()
+        .name("test")
+        .method(PipelineTaskQueue.TaskSpec.Method.GET)
+        .service("testService")
+        .callbackPath("/test")
+      .param("param1", "value2")
+        .build();
+
+    assertNotEquals(taskSpec, taskSpec3);
+  }
+
+}


### PR DESCRIPTION
> This pull request addresses two main updates. First, it fixes the task enqueuing check by adding a warning when it appears that duplicate tasks are being enqueued, helping to avoid redundant processing and potential errors. Second, it "Lombokifies" the `Barrier` class, employing Project Lombok to reduce boilerplate code and enhance readability and maintainability.

### Fixes
> This pull request fixes an issue related to the duplication of task enqueue warnings which could lead to redundant operations. However, no specific GitHub issues are referenced.

### Features
> The enhancement of the `Barrier` class through the use of Lombok is a new feature. No specific GitHub issues are referenced.

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **yes** (Project Lombok dependency is introduced or expanded, which may impact project setup)
