### PR TITLE
s196 - Remove parallel streams

### DIFF
--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineBackEnd.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/AppEngineBackEnd.java
@@ -506,9 +506,8 @@ public class AppEngineBackEnd implements PipelineBackEnd, SerializationStrategy 
       public Map<Key, Entity> call() {
         //NOTE: this read is strongly consistent now, bc backed by Firestore in Datastore-mode; this library was
         // designed thinking this read was only event
-        return keys.stream()
-          .parallel()
-          .map(datastore::get)
+        return datastore.fetch(keys)
+          .stream()
           .filter(Objects::nonNull)
           .collect(Collectors.toMap(Entity::getKey, Function.identity()));
       }

--- a/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/CloudTasksTaskQueue.java
+++ b/java/src/main/java/com/google/appengine/tools/pipeline/impl/backend/CloudTasksTaskQueue.java
@@ -99,8 +99,7 @@ public class CloudTasksTaskQueue implements PipelineTaskQueue {
     // synchronized to deal with parallel stream
     Collection<TaskReference> taskReferences = Collections.synchronizedList(new ArrayList<>());
     try (CloudTasksClient cloudTasksClient = cloudTasksClientProvider.get()) {
-      taskSpecs.parallelStream()
-        .forEach(taskSpec -> {
+      taskSpecs.forEach(taskSpec -> {
           Task task = createTask(cloudTasksClient, queue, taskSpec);
           taskReferences.add(TaskReference.of(queueName, TaskName.parse(task.getName()).getTask()));
         });


### PR DESCRIPTION
### Fixes
- Remove uses parallel as not clear if this could pose a problem in automatic scale service

### Change implications

 - breaking change to API? **no**
 - changes dependencies?  **no**
