### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -1,5 +1,7 @@
 # test java version of library
 name: Test Java
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Worklytics/appengine-pipelines/security/code-scanning/8](https://github.com/Worklytics/appengine-pipelines/security/code-scanning/8)

To fix the problem, explicitly define minimal `GITHUB_TOKEN` permissions in the workflow. Since neither job needs to write to the repository or manage issues/PRs, we can safely set `contents: read` at the workflow level, which applies to all jobs that do not override permissions. This adheres to the principle of least privilege and satisfies CodeQL’s recommendation.

The best minimal, non-breaking change: in `.github/workflows/test-java.yml`, add a `permissions:` block right after the `name: Test Java` line (before the `on: [push]` line). Set `contents: read`. No changes are needed inside the `jobs:` section, and no imports or additional definitions are required, because this is purely a workflow configuration change.

Concretely:
- Edit `.github/workflows/test-java.yml`.
- After line 2 (`name: Test Java`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
